### PR TITLE
Start server on the next unoccupied port

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
     - $HOME/.composer/cache
 
 script:
-  - ./hyper-run -S localhost:8080 -s localhost:8081 -n 5 -t examples &
+  - ./hyper-run -S localhost:8000 -s localhost:44300 -n 5 -t examples &
   - vendor/bin/codecept run unit
   - kill $!
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ hyper-run -S localhost:8080 -s localhost:4000 -t src/app/www
 
 2 servers will start with the directory `src/app/www` as the document root:
 
-- [http://localhost:8080](http://localhost:8080)
-- [https://localhost:4000](https://localhost:4000)
+- <a href="http://localhost:8080" target="_blank">http://localhost:8080</a>
+- <a href="http://localhost:4000" target="_blank">http://localhost:4000</a>
 
 ### Command Reference
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ hyper-run -S localhost -s localhost -t src/app/www
 
 2 servers will start with the directory `src/app/www` as the document root:
 
-- [http://localhost:8000](http://localhost:8000)
-- [https://localhost:44300](https://localhost:44300)
+- `http://localhost:8000`
+- `https://localhost:44300`
 
 Servers start with first unoccupied port within range depending on a scheme.
 
@@ -53,8 +53,8 @@ hyper-run -S localhost:8080 -s localhost:4000 -t src/app/www
 
 2 servers will start with the directory `src/app/www` as the document root:
 
-- <a href="http://localhost:8080" target="_blank">http://localhost:8080</a>
-- <a href="http://localhost:4000" target="_blank">http://localhost:4000</a>
+- `http://localhost:8080`
+- `https://localhost:4000`
 
 ### Command Reference
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Usage:
     hyper-run <options>
 
 Example:
-    hyper-run -S localhost:8080 -s localhost:8081
+    hyper-run -S localhost:8000 -s localhost:44300
 
 [Required]
     -S   "<Host>:<Port>" of an HTTP server. Multiple arguments can be accepted.
@@ -54,18 +54,34 @@ Restrictions:
 mpyw@localhost:~$
 ```
 
-## Example
+### Quick start
 
 ```shell script
-hyper-run -S localhost:8080 -s localhost:8081 -t src/app/www
+hyper-run -S localhost -s localhost -t src/app/www
 ```
 
-It listens on
+2 servers will start with the directory `src/app/www` as the document root:
+
+- `http://localhost:8000`
+- `https://localhost:44300`
+
+Servers start with first unoccupied port within range depending on a scheme.
+
+| Scheme  | Default | Range       |
+| ------- | ------- | ----------- |
+| `HTTP`  | 8000    | 8000-8099   |
+| `HTTPS` | 44300   | 44300-44399 |
+
+### Customize ports
+
+```shell script
+hyper-run -S localhost:8080 -s localhost:4000 -t src/app/www
+```
+
+2 servers will start with the directory `src/app/www` as the document root:
 
 - `http://localhost:8080`
-- `https://localhost:8081`
-
-using the directory `src/app/www` as the document root.
+- `https://localhost:4000`
 
 ## Note for Windows users
 

--- a/README.md
+++ b/README.md
@@ -27,33 +27,6 @@ Use **`vendor/bin/hyper-run`** as the execution path.
 
 ## Usage
 
-```ShellSession
-mpyw@localhost:~$ hyper-run -h
-
-Usage:
-    hyper-run <options>
-
-Example:
-    hyper-run -S localhost:8000 -s localhost:44300
-
-[Required]
-    -S   "<Host>:<Port>" of an HTTP server. Multiple arguments can be accepted.
-    -s   "<Host>:<Port>" of an HTTPS server. Multiple arguments can be accepted.
-
-[Optional]
-    -n   The number of PHP built-in server clusters, from 1 to 20. Default is 10.
-    -t   Path for the document root. Default is the current directory.
-    -r   Path for the router script. Default is empty.
-    -c   Path for the PEM-encoded certificate.
-         Default is "/Users/mpyw/.composer/vendor/mpyw/php-hyper-builtin-server/certificate.pem".
-
-Restrictions:
-    - The option -s is only supported on PHP 5.6.0 or later.
-    - Access logs will not be displayed on Windows.
-
-mpyw@localhost:~$
-```
-
 ### Quick start
 
 ```shell script
@@ -82,6 +55,35 @@ hyper-run -S localhost:8080 -s localhost:4000 -t src/app/www
 
 - `http://localhost:8080`
 - `https://localhost:4000`
+
+### Command Reference
+
+```ShellSession
+mpyw@localhost:~$ hyper-run -h
+
+Usage:
+    hyper-run <options>
+
+Example:
+    hyper-run -S localhost:8000 -s localhost:44300
+
+[Required]
+    -S   "<Host>:<Port>" of an HTTP server. Multiple arguments can be accepted.
+    -s   "<Host>:<Port>" of an HTTPS server. Multiple arguments can be accepted.
+
+[Optional]
+    -n   The number of PHP built-in server clusters, from 1 to 20. Default is 10.
+    -t   Path for the document root. Default is the current directory.
+    -r   Path for the router script. Default is empty.
+    -c   Path for the PEM-encoded certificate.
+         Default is "/Users/mpyw/.composer/vendor/mpyw/php-hyper-builtin-server/certificate.pem".
+
+Restrictions:
+    - The option -s is only supported on PHP 5.6.0 or later.
+    - Access logs will not be displayed on Windows.
+
+mpyw@localhost:~$
+```
 
 ## Note for Windows users
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ hyper-run -S localhost -s localhost -t src/app/www
 
 2 servers will start with the directory `src/app/www` as the document root:
 
-- `http://localhost:8000`
-- `https://localhost:44300`
+- [http://localhost:8000](http://localhost:8000)
+- [https://localhost:44300](https://localhost:44300)
 
 Servers start with first unoccupied port within range depending on a scheme.
 
@@ -53,8 +53,8 @@ hyper-run -S localhost:8080 -s localhost:4000 -t src/app/www
 
 2 servers will start with the directory `src/app/www` as the document root:
 
-- `http://localhost:8080`
-- `https://localhost:4000`
+- [http://localhost:8080](http://localhost:8080)
+- [https://localhost:4000](https://localhost:4000)
 
 ### Command Reference
 

--- a/hyper-run
+++ b/hyper-run
@@ -85,7 +85,9 @@ function startListener($master, $listener)
     } catch (React\Socket\ConnectionException $exception) {
         $reason = 'Address already in use';
 
-        if (strpos($exception->getMessage(), $reason) === false) {
+        $isPortSpecified = $listener[4];
+
+        if ($isPortSpecified || strpos($exception->getMessage(), $reason) === false) {
             throw $exception;
         }
 
@@ -119,8 +121,17 @@ try {
 
     $listeners = [];
     foreach ([$servers, $secures] as $type => $group) {
+        $isSecure = $type === 1;
         foreach ($group as $i => $server) {
             list($host, $port) = explode(':', $server, 2) + [1 => ''];
+
+            if ($port === '') {
+                $port = $isSecure ? '44300' : '8000';
+                $isPortSpecified = false;
+            } else {
+                $isPortSpecified = true;
+            }
+
             $ip = filter_var(gethostbyname($host), FILTER_VALIDATE_IP, FILTER_FLAG_IPV4);
             $regex = '/\A(?:[0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])\z/';
             if ($ip === false || !preg_match($regex, $port)) {
@@ -129,7 +140,7 @@ try {
             if (isset($listeners[$server])) {
                 throw new \RuntimeException("Duplicated entry: $server");
             }
-            $listeners[$server] = [$host, $port, $type === 1, $cert];
+            $listeners[$server] = [$host, $port, $isSecure, $cert, $isPortSpecified];
         }
     }
 

--- a/hyper-run
+++ b/hyper-run
@@ -30,7 +30,7 @@ Usage:
     $_SERVER[SCRIPT_NAME] <options>
 
 Example:
-    $_SERVER[SCRIPT_NAME] -S localhost:8080 -s localhost:8081
+    $_SERVER[SCRIPT_NAME] -S localhost:8000 -s localhost:44300
 
 [Required]
     -S   \"<Host>:<Port>\" of an HTTP server. Multiple arguments can be accepted.

--- a/hyper-run
+++ b/hyper-run
@@ -72,6 +72,33 @@ if (!$servers && !$secures) {
     exit(1);
 }
 
+function startListener($master, $listener)
+{
+    $host = sprintf(
+        '%s://%s:%s',
+        $listener[2] ? 'https' : 'http', $listener[0], $listener[1]
+    );
+    fwrite(STDOUT, "Development server started: <{$host}>\n");
+
+    try {
+        call_user_func_array([$master, 'addListener'], $listener);
+    } catch (React\Socket\ConnectionException $exception) {
+        $reason = 'Address already in use';
+
+        if (strpos($exception->getMessage(), $reason) === false) {
+            throw $exception;
+        }
+
+        fwrite(STDERR, sprintf(
+            "Failed to listen on %s:%s (reason: %s)\n",
+            $listener[0], $listener[1], $reason
+        ));
+
+        $listener[1] = (int) $listener[1] + 1;
+        startListener($master, $listener);
+    }
+}
+
 try {
 
     if (!ctype_digit($number) || $number < 1 || $number > 20) {
@@ -116,13 +143,7 @@ try {
         $usedProcesses = $processes;
         $master = new mpyw\HyperBuiltinServer\Master($loop, $processes);
         foreach ($listeners as $listener) {
-            call_user_func_array([$master, 'addListener'], $listener);
-
-            $host = sprintf(
-                '%s://%s:%s',
-                $listener[2] ? 'https' : 'http', $listener[0], $listener[1]
-            );
-            fwrite(STDOUT, "Development server started: <{$host}>\n");
+            startListener($master, $listener);
         }
     })
     ->then(null, function ($e) use (&$usedProcesses) {

--- a/tests/unit/RemoteSimpleTest.php
+++ b/tests/unit/RemoteSimpleTest.php
@@ -53,55 +53,55 @@ class RemoteSimpleTest extends \Codeception\TestCase\Test
 
     public function testSimple()
     {
-        Co::wait($ch = $this->curlInitWith('http://localhost:8080/upload_form.php'));
+        Co::wait($ch = $this->curlInitWith('http://localhost:8000/upload_form.php'));
         $this->curlAssert200OK($ch);
     }
 
     public function testSimpleSecure()
     {
-        Co::wait($ch = $this->curlInitWith('https://localhost:8081/upload_form.php'));
+        Co::wait($ch = $this->curlInitWith('https://localhost:44300/upload_form.php'));
         $this->curlAssert200OK($ch);
     }
 
     public function testDelayed()
     {
-        Co::wait($ch = $this->curlInitWith('http://localhost:8080/fast_hello.php'));
+        Co::wait($ch = $this->curlInitWith('http://localhost:8000/fast_hello.php'));
         $this->curlAssert200OK($ch);
     }
 
     public function testDelayedSecure()
     {
-        Co::wait($ch = $this->curlInitWith('https://localhost:8081/fast_hello.php'));
+        Co::wait($ch = $this->curlInitWith('https://localhost:44300/fast_hello.php'));
         $this->curlAssert200OK($ch);
     }
 
     public function testDelayedGroupSingle()
     {
-        Co::wait($chs = $this->curlsInitWith(5, 'http://localhost:8080/fast_hello.php'));
+        Co::wait($chs = $this->curlsInitWith(5, 'http://localhost:8000/fast_hello.php'));
         $this->curlsAssert200OK($chs);
     }
 
     public function testDelayedGroupSingleSecure()
     {
-        Co::wait($chs = $this->curlsInitWith(5, 'https://localhost:8081/fast_hello.php'));
+        Co::wait($chs = $this->curlsInitWith(5, 'https://localhost:44300/fast_hello.php'));
         $this->curlsAssert200OK($chs);
     }
 
     public function testDelayedGroupDouble()
     {
-        Co::wait($chs = $this->curlsInitWith(10, 'http://localhost:8080/fast_hello.php'));
+        Co::wait($chs = $this->curlsInitWith(10, 'http://localhost:8000/fast_hello.php'));
         $this->curlsAssert200OK($chs);
     }
 
     public function testDelayedGroupDoubleSecure()
     {
-        Co::wait($chs = $this->curlsInitWith(10, 'https://localhost:8081/fast_hello.php'));
+        Co::wait($chs = $this->curlsInitWith(10, 'https://localhost:44300/fast_hello.php'));
         $this->curlsAssert200OK($chs);
     }
 
     public function testDelayedGroupDoubleAtOnce()
     {
-        Co::wait($chs = $this->curlsInitWith(10, 'http://localhost:8080/fast_hello.php'), [
+        Co::wait($chs = $this->curlsInitWith(10, 'http://localhost:8000/fast_hello.php'), [
             'concurrency' => 0,
         ]);
         $this->curlsAssert200OK($chs);
@@ -109,7 +109,7 @@ class RemoteSimpleTest extends \Codeception\TestCase\Test
 
     public function testDelayedGroupDoubleAtOnceSecure()
     {
-        Co::wait($chs = $this->curlsInitWith(10, 'https://localhost:8081/fast_hello.php'), [
+        Co::wait($chs = $this->curlsInitWith(10, 'https://localhost:44300/fast_hello.php'), [
             'concurrency' => 0,
         ]);
         $this->curlsAssert200OK($chs);


### PR DESCRIPTION
This feature is very useful when you are starting multiple servers. If your port is occupied - it will try to start it on the next free port.

@mpyw what do you think?

If you don't like to have this feature enabled by default - we could add option `-f` to enable this feature, like:

```shell script
hyper-run -s localhost:4000 -f -c ~/cert.pem -t ./public
```

![Screenshot from 2020-06-02 03-05-08](https://user-images.githubusercontent.com/1849174/83465844-e8b0f580-a47d-11ea-9047-3920ae69681b.png)
